### PR TITLE
Replaced GAZ_00000448 with GEO_000000372 

### DIFF
--- a/src/imports/externalByhand.owl
+++ b/src/imports/externalByhand.owl
@@ -384,17 +384,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GAZ_00000448 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GAZ_00000448">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A reference to a place on the Earth, by its name or by its geographical location.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/gaz.owl"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">geographic location</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/IAO_0000027 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000027"/>

--- a/src/obib_dev.owl
+++ b/src/obib_dev.owl
@@ -711,15 +711,15 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GAZ_00000448 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GAZ_00000448"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GEO_000000006 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000006"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GEO_000000372 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000372"/>
     
 
 
@@ -10329,7 +10329,7 @@ nature as collections of samples and data.&quot;</obo:IAO_0000115>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000448"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GEO_000000372"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115 xml:lang="en">A textual entity that is part of a postal address and denotes a human settlement for the purpose of delivering mail.</obo:IAO_0000115>
@@ -11071,7 +11071,7 @@ nature as collections of samples and data.&quot;</obo:IAO_0000115>
                         <owl:someValuesFrom>
                             <owl:Class>
                                 <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GAZ_00000448"/>
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GEO_000000372"/>
                                     <owl:Restriction>
                                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001015"/>
                                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBIB_0000616"/>


### PR DESCRIPTION
Replaced GAZ_00000448 'geographic location' with GEO_000000372 'geographical region.'
(issue https://github.com/biobanking/biobanking/issues/86 )

Full Changes:
Replaced GAZ_00000448 with GEO_000000372 in axioms for the following terms:
OBIB_0000641 'settlement part of address'
OBIB_0000656 'biobank location ISO 3166-1 alpha-2 code'
Removed GAZ from imports.